### PR TITLE
Evolution: a datable type sentence can be matched with a RegEx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3011,7 +3011,6 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
           "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
@@ -3023,8 +3022,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
           "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/test/specs/features/step-definitions/using-gherkin-tables.steps.js
+++ b/test/specs/features/step-definitions/using-gherkin-tables.steps.js
@@ -22,7 +22,8 @@ When( 'I add the following task:', table => {
     });
 });
 
-Then( 'I should see the following todo list:', table => {
+Then( /^I should see the following (\d) todos in my list:$/, (nbre, table) => {
+    expect(todoList.items.length).toBe(parseInt(nbre))
     expect(todoList.items.length).toBe(table.length)
 
     table.forEach((row, index) => {

--- a/test/specs/features/using-gherkin-tables.feature
+++ b/test/specs/features/using-gherkin-tables.feature
@@ -1,14 +1,16 @@
 Feature: Todo List
 
-Scenario: Adding an item to my todo list
+  Scenario: Adding an item to my todo list
     Given my todo list currently looks as follows:
-    | TaskName            | Priority |
-    | Fix bugs in my code | medium   |
-    | Document my hours   | medium   |
+      | TaskName            | Priority |
+      | Fix bugs in my code | medium   |
+      | Document my hours   | medium   |
     When I add the following task:
-    | TaskName                              | Priority |
-    | Watch cat videos on YouTube all day   | high     |
-    Then I should see the following todo list:
-    | TaskName                              | Priority |  
-    | Watch cat videos on YouTube all day   | high     |
-    | Sign up for unemployment              | high     |
+      | TaskName                            | Priority |
+      | Watch cat videos on YouTube all day | high     |
+      | Document my hours                   | medium   |
+    Then I should see the following 2 todos in my list:
+      | TaskName                            | Priority |
+      | Watch cat videos on YouTube all day | high     |
+      | Sign up for unemployment            | high     |
+


### PR DESCRIPTION
Hello,
Happy New Year !

I added the possibility of having a sentence can be matched with regEx when it is a datatable. 
It is useful in my project to have only one parameterizable sentence example:
``` feature
[...]
Then I should see the following 2 todos in my list:
      | TaskName      | Priority |
      | Watch the cat | high     |
      | Registration  | high     |
```

and another Scanario
``` feature
[...]
Then I should see the following 3 todos in my list:
      | TaskName      | Priority |
      | Watch the cat | high     |
      | Registration  | high     |
      | Journal       | high     |
```

It allows me to have only 1 sentence

```javascript
Then(/^I should see the following (\d) todos in my list:$/, (param1, table) => {
   expect(table[0].TaskName).toBe('Watch the cat')
})
```

The datatable should always be the last parameter.